### PR TITLE
Keep master up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y
 
 RUN apt-get install -y python
 
-RUN apt-get install python-pip
+RUN apt-get install -y python-pip
 
 RUN pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ MAINTAINER John Garza <johnegarza@wustl.edu>
 LABEL \
     description="Image supporting a helper python script"
 
-RUN apt-get update -y
-
-RUN apt-get install -y python
-
-RUN apt-get install -y python-pip
+#libcurl4, libssl, zlib1g are necessary for pip to install cyvcf2
+RUN apt-get update -y && apt-get install -y \
+python \
+python-pip \
+libcurl4-openssl-dev \
+libssl-dev \
+zlib1g-dev
 
 RUN pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,10 @@ RUN apt-get update -y
 
 RUN apt-get install -y python
 
+RUN apt-get install python-pip
+
+RUN pip install --upgrade pip
+
+RUN pip install cyvcf2
+
 COPY add_annotations_to_table_helper.py /usr/bin/add_annotations_to_table_helper.py


### PR DESCRIPTION
Opening a PR, despite already making the 1.0.2 branch and adding that version of the docker image to cwl workflows, in order to have a write up of this later. The Dockerfile was accidentally reverted to the original version in the 1.0.1 branch (probably because the master branch did not have the updates, only 1.0.0), which did not contain the python cyvcf2 library or the libraries needed for pip to install it. Added those back in, released in 1.0.2, and now merging into master to prevent that again.